### PR TITLE
Fix fuction for php 7.1.33

### DIFF
--- a/marking/locallib.php
+++ b/marking/locallib.php
@@ -31,7 +31,7 @@
  * @param unknown $context
  * @return multitype:stdClass
  */
-function emarking_get_all_pages($emarking, $submission, $draft, $studentanonymous, $context, $winwidth, $winheight) {
+function emarking_get_all_pages($emarking, $submission, $draft, $studentanonymous, $context, $winwidth = 0, $winheight = 0) {
     global $DB, $CFG, $USER;
     $emarkingpages = array();
     // Get criteria to filter pages.


### PR DESCRIPTION
Set default arguments in emarking_get_all_pages() function. Tested in php 7.0.33 and 7.1.33